### PR TITLE
add host based 2FA bypass

### DIFF
--- a/duo_seraph_filter/src/main/java/com/duosecurity/seraph/filter/DuoAuthFilter.java
+++ b/duo_seraph_filter/src/main/java/com/duosecurity/seraph/filter/DuoAuthFilter.java
@@ -55,6 +55,8 @@ public class DuoAuthFilter implements javax.servlet.Filter {
   private ArrayList<String> unprotectedDirs;
   private boolean apiBypassEnabled = false;
   private boolean failOpen = false;
+  private ArrayList<String> bypassHosts;
+
 
   /**
    * Return true if url should not be protected by Duo auth, even if we have
@@ -168,6 +170,28 @@ public class DuoAuthFilter implements javax.servlet.Filter {
 
   }
 
+
+  private boolean remoteHostIsBypassed(String remoteAddr) {
+    if (remoteAddr==null) {
+      log.error("remoteAddr is null, this should never happen.");
+      return false;
+    }
+
+    if (bypassHosts!=null) {
+      if (bypassHosts.contains(remoteAddr)) {
+        if (log.isDebugEnabled()) {
+          log.debug("host "+remoteAddr+" is whitelisted.");
+        }
+        return true;
+      }
+    }
+
+    if (log.isDebugEnabled()) {
+      log.debug("host "+remoteAddr+ " is not whitelisted.");
+    }
+    return false;
+  }
+
   @Override public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
   throws java.io.IOException, javax.servlet.ServletException {
     HttpServletRequest httpServletRequest = (HttpServletRequest) request;
@@ -178,45 +202,47 @@ public class DuoAuthFilter implements javax.servlet.Filter {
     Principal principal = httpServletRequest.getUserPrincipal();
 
     String contextPath = ((HttpServletRequest) request).getContextPath();
-
-    if (!isUnprotectedPage(httpServletRequest.getRequestURI().replaceFirst(contextPath, ""))) {
-      if (request.getAttribute(OS_AUTHSTATUS_KEY) != null && apiBypassEnabled && principal != null) {
-        // Request has gone through OAuth, we're done if it succeeded
-        if (!request.getAttribute(OS_AUTHSTATUS_KEY).equals(LOGIN_SUCCESS)) {
-          throw new ServletException("OAuth authentication failed");
-        }
-      } else if (principal != null) {
-        // User has logged in locally, has there been a Duo auth?
-        if (session.getAttribute(DUO_AUTH_SUCCESS_KEY) == null) {
-          // are we coming from the Duo auth servlet?
-          String duoResponse = (String) session.getAttribute(DUO_RESPONSE_ATTRIBUTE);
-          if (duoResponse != null) {
-            String duoUsername = null;
-            try {
-              duoUsername = DuoWeb.verifyResponse(ikey, skey, akey, duoResponse);
-            } catch (DuoWebException e) {
-              e.printStackTrace();
-              log.error(e.getMessage());
-            } catch (NoSuchAlgorithmException e) {
-              e.printStackTrace();
-              log.error(e.getMessage());
-            } catch (InvalidKeyException e) {
-              e.printStackTrace();
-              log.error(e.getMessage());
-            }
-            if (duoUsername != null && duoUsername.equals(principal.getName())) {
-              session.setAttribute(DUO_AUTH_SUCCESS_KEY, true);
+    if (remoteHostIsBypassed(httpServletRequest.getRemoteAddr())) {
+      needAuth=false;
+    } else {
+      if (!isUnprotectedPage(httpServletRequest.getRequestURI().replaceFirst(contextPath, ""))) {
+        if (request.getAttribute(OS_AUTHSTATUS_KEY) != null && apiBypassEnabled && principal != null) {
+          // Request has gone through OAuth, we're done if it succeeded
+          if (!request.getAttribute(OS_AUTHSTATUS_KEY).equals(LOGIN_SUCCESS)) {
+            throw new ServletException("OAuth authentication failed");
+          }
+        } else if (principal != null) {
+          // User has logged in locally, has there been a Duo auth?
+          if (session.getAttribute(DUO_AUTH_SUCCESS_KEY) == null) {
+            // are we coming from the Duo auth servlet?
+            String duoResponse = (String) session.getAttribute(DUO_RESPONSE_ATTRIBUTE);
+            if (duoResponse != null) {
+              String duoUsername = null;
+              try {
+                duoUsername = DuoWeb.verifyResponse(ikey, skey, akey, duoResponse);
+              } catch (DuoWebException e) {
+                e.printStackTrace();
+                log.error(e.getMessage());
+              } catch (NoSuchAlgorithmException e) {
+                e.printStackTrace();
+                log.error(e.getMessage());
+              } catch (InvalidKeyException e) {
+                e.printStackTrace();
+                log.error(e.getMessage());
+              }
+              if (duoUsername != null && duoUsername.equals(principal.getName())) {
+                session.setAttribute(DUO_AUTH_SUCCESS_KEY, true);
+              } else {
+                needAuth = true;
+              }
             } else {
               needAuth = true;
             }
-          } else {
-            needAuth = true;
-          }
-        } // user has already authed with us this session
-      } // no user -> Seraph has not required auth -> we don't either,
+          } // user has already authed with us this session
+        } // no user -> Seraph has not required auth -> we don't either,
         // or user came from OAuth and we're configured to not require 2fa for that
-    }     // we're serving a page for Duo auth
-
+      }     // we're serving a page for Duo auth
+    }
     if (needAuth) {
       if (shouldDuoAuthn(principal)) {
         redirectDuoAuth(principal, httpServletRequest, httpServletResponse, contextPath);
@@ -253,7 +279,19 @@ public class DuoAuthFilter implements javax.servlet.Filter {
     if (filterConfig.getInitParameter("fail.Open") != null) {
       failOpen = Boolean.parseBoolean(filterConfig.getInitParameter("fail.Open"));
     }
+
+    /*
+      Supports bypassing 2FA for whitelisted hosts for example for API access.
+      "bypass.hosts" is a list of 1..n IP addresses seperated by space (" ")
+     */
+    if (filterConfig.getInitParameter("bypass.hosts") != null) {
+
+    String[] userSpecifiedBypassHosts = filterConfig.getInitParameter("bypass.hosts").split(" ");
+    bypassHosts = new ArrayList<String>(Arrays.asList(userSpecifiedBypassHosts));
+    log.info("request from the following hosts will bypass DUO 2FA"+Arrays.toString(userSpecifiedBypassHosts));
   }
+}
+
 
   @Override public void destroy() {
 


### PR DESCRIPTION
Running the Confluence&JIRA on-prem with DUO and the current plugin breaks Confluence<->JIRA integration since API calls between the two systems fail. 
This change permits individual hosts to be excluded from 2FA (whitelisting).
In practice one would whitelist the Confluence host(s) and potentially also 127.0.0.1.

This also resolves 50% of support case *** and compliments https://github.com/duosecurity/duo_confluence/pull/7

 Howto:
Add an init-param the duo- in /jira/WEB-INF/web.xml "duoauth" filter like this:

<param-name>bypass.hosts</param-name>
        <param-value>10.1.1.2 10.1.1.3 127.0.0.1</param-value>
  </init-param>
Hosts have to be numeric (no symbolic names) and are seperated by a " ". IPv6 should work but is untested. If you want to see what's going on, configure "com.duosecurity.seraph.filter" with log level "DEBUG" in the JIRA admin "Logging & Profiling section".

I will preparere a similar change for the Confluence plugin.
Tested on  JIRA 7.11.0
Works with reverse proxies via Tomcat's RemoteIpValve (which need to be configured in server.xml)