### PR TITLE
Fix broken 2FA page in Jira server 8.7.1

### DIFF
--- a/duo_twofactor/src/main/resources/duologin.vm
+++ b/duo_twofactor/src/main/resources/duologin.vm
@@ -11,7 +11,7 @@
 
      <div>
        <script type="text/javascript" src="$contextPath/download/resources/com.duosecurity.jira.plugins.duo-twofactor:resources/Duo-Web-v2.js"></script>
-       <script>
+       <script type="text/javascript">
          Duo.init({
            'host': "$duoHost",
            'sig_request': "$sigRequest",


### PR DESCRIPTION
Atlassian appears to have enabled strict mime type checking in recent versions of Jira.  This caused the Duo.init call to fail due to the missing script "type" attribute.